### PR TITLE
fb: fix non-fullscreen framebuffer update

### DIFF
--- a/src/aroma/graph/fb.c
+++ b/src/aroma/graph/fb.c
@@ -312,7 +312,7 @@ byte libaroma_fb_sync() {
   if (libaroma_fb_start_post()){
     if (_libaroma_fb->post(_libaroma_fb, _libaroma_fb->canvas->data,
         0, 0, _libaroma_fb->w, _libaroma_fb->h,
-        0, 0, _libaroma_fb->w, _libaroma_fb->h)){
+        0, 0, _libaroma_fb->canvas->l, _libaroma_fb->h)){
       ret = 1;
     }
     libaroma_fb_end_post();
@@ -362,7 +362,7 @@ byte libaroma_fb_sync_area(
   if (libaroma_fb_start_post()){
     if (_libaroma_fb->post(_libaroma_fb, _libaroma_fb->canvas->data,
         x, y, w, h,
-        x, y, _libaroma_fb->w, _libaroma_fb->h)){
+        x, y, _libaroma_fb->canvas->l, _libaroma_fb->h)){
       ret = 1;
     }
     libaroma_fb_end_post();


### PR DESCRIPTION
While updating just a region and not the full framebuffer, there was distortion because of using canvas width instead of line size (which is 4x the width).
This was most notably affecting SDL usage.